### PR TITLE
:hammer: dynamic route with clearer urls for each product

### DIFF
--- a/components/Product.js
+++ b/components/Product.js
@@ -16,8 +16,8 @@ const Product = ( props ) => {
 				</h3>
 
 				<Link
-					as={ `/product/${ product.slug }-${ product.productId }` }
-					href={ `/product?slug=${ product.slug }-${ product.productId }` }
+					as={ `/product/${ product.slug }`}
+					href={`/product/[slug]`}
 				>
 					<a>
 						{ !isEmpty( product.image ) ? (

--- a/pages/product/[slug].js
+++ b/pages/product/[slug].js
@@ -1,13 +1,18 @@
-import Layout from '../components/Layout';
-import { withRouter } from 'next/router';
-import client from '../components/ApolloClient';
-import AddToCartButton from '../components/cart/AddToCartButton';
-import PRODUCT_BY_ID_QUERY from '../queries/product-by-id';
-import clientConfig from '../client-config';
+import Layout from '../../components/Layout';
+//import { useRouter } from 'next/router';
+import client from '../../components/ApolloClient';
+import AddToCartButton from '../../components/cart/AddToCartButton';
+import PRODUCT_BY_SLUG_QUERY from '../../queries/product-by-slug';
+import clientConfig from '../../client-config';
 import { isEmpty } from 'lodash';
 
-const Product = withRouter( ( props ) => {
+const Product = (props) => {
 	const { product } = props;
+
+	//const router = useRouter()
+    //const { slug } = router.query 
+	// console.log(slug)  /* check the slug */
+
 
 	return (
 		<Layout>
@@ -30,7 +35,7 @@ const Product = withRouter( ( props ) => {
 									alt="Placeholder product image"
 								/>
 							) : null }
-							<p
+							<div
 								dangerouslySetInnerHTML={ {
 									__html: product.description,
 								} }
@@ -46,21 +51,27 @@ const Product = withRouter( ( props ) => {
 			) }
 		</Layout>
 	);
-} );
-
-Product.getInitialProps = async function ( context ) {
-	let {
-		    query: { slug },
-	    }     = context;
-	const id  = slug ? parseInt( slug.split( '-' ).pop() ) : context.query.id;
-	const res = await client.query( {
-		query: PRODUCT_BY_ID_QUERY,
-		variables: { id },
-	} );
-
-	return {
-		product: res.data.product,
-	};
 };
+
+
+export const getServerSideProps = async (context) => {
+
+    let {query: { slug }} = context
+
+    const id = slug ? slug : context.query.id;
+
+
+    const result = await client.query({
+        query: PRODUCT_BY_SLUG_QUERY,
+        variables: { id }
+    })
+
+    return {
+        props: {
+            product: result.data.product,
+            revalidate: 1,
+        },
+    };
+}
 
 export default Product;

--- a/queries/product-by-slug.js
+++ b/queries/product-by-slug.js
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
-const PRODUCT_BY_ID_QUERY = gql` query Product($id: ID!) {
-	product(id: $id, idType: DATABASE_ID) {
+const PRODUCT_BY_SLUG_QUERY = gql` query Product($id: ID!) {
+	product(id: $id, idType: SLUG) {
 	  id
 	  productId
 	  averageRating
@@ -43,4 +43,4 @@ const PRODUCT_BY_ID_QUERY = gql` query Product($id: ID!) {
   }
 `;
 
-export default PRODUCT_BY_ID_QUERY;
+export default PRODUCT_BY_SLUG_QUERY;


### PR DESCRIPTION
in terms of SEO it would be nice if the slug better reflects the content and keywords. In this case I want to eliminate the product id from permalink

As for what I changed from the source code is

- Product directories from `product.js` to` product / [slug]. Js`, referring to [dynamic routing](https://nextjs.org/docs/routing/introduction) Next.js version 9 and above 
- Change the variable type based on the `product / [slug] .js` slug
- Change `getInitialProps` to` getServerSideProps` as the [docs](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps) recommended

